### PR TITLE
add json support in appearance screen with drag and drop

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -52,8 +52,8 @@ export default function Editor({confirmDialog,animationManager, blinkManager, lo
   useEffect(() => {
     if (awaitDisplay){
       setSelectedOptions(
-        loadUserSelection(manifestSelectionIndex)
-        || getRandomizedTemplateOptions(templateInfo)
+        //loadUserSelection(manifestSelectionIndex)
+        getRandomizedTemplateOptions(templateInfo)
       )
         setAwaitDisplay(false)
     }

--- a/src/components/Selector.jsx
+++ b/src/components/Selector.jsx
@@ -144,7 +144,6 @@ export default function Selector({confirmDialog, templateInfo, animationManager,
       const finalAvatar = {...avatar, ...newAvatar}
       setTimeout(() => {
         if (Object.keys(finalAvatar).length > 0) {
-          console.log(finalAvatar)
           cullHiddenMeshes(finalAvatar)
         }
         !isMute && playSound('characterLoad',300);

--- a/src/library/option-utils.js
+++ b/src/library/option-utils.js
@@ -70,6 +70,33 @@ export const getClassOptions = (manifest) => {
   return options
 }
 
+export function getTraitOption(traitId, traitName, template){
+  
+
+  const trait = template.traits.find(trait => trait.trait === traitName)
+
+  if (trait == null){
+    console.warn("No trait with id: " + traitName + " was found.");
+    return null;
+  }
+  let index = trait.collection?.findIndex(item => item.id === traitId);
+  index = index != null ? index : -1;
+  
+  
+  if (index != -1){
+    const item = trait.collection[index];
+
+    const key = trait.name + "_" + index;
+    const thumbnailBaseDir = (template.assetsLocation || "") + template.thumbnailsDirectory
+    return  getOption(key, trait, item, thumbnailBaseDir + item.thumbnail);
+  }
+  else{
+    console.warn("No object with id: " + traitId + " was found in trait category " + traitName);
+    return null;
+  }
+    
+}
+
 export function getTraitOptions(trait, template) {
   const traitOptions = []
   const thumbnailBaseDir = (template.assetsLocation || "") + template.thumbnailsDirectory


### PR DESCRIPTION
This PR supports drag and dropping json files in the next structure: (example)

{ "name": "5", "attributes": [
{
"trait_type": "BODY",
"value": "Feminine"
},
{
"trait_type": "CLOTHING",
"value": "Blue_Blazer_with_Bow"
},
{
"trait_type": "HAIR",
"value": "Mid_Green"
},
{
"trait_type": "TYPE",
"value": "Devil"
},
{
"trait_type": "HEAD",
"value": "Devil_Horns_Gilded"
},
{
"trait_type": "SIGIL",
"value": "Red_Dragon_Laser_Sigil_plus_Beam_Sigil"
},
{
"trait_type": "BRACE",
"value": "Festival_Mask_Oni_Brace"
}
] }

https://github.com/M3-org/CharacterStudio/assets/1117257/8ce95f71-06d8-4c88-8956-264132a342b4


 