### PR TITLE
Properly dispose index buffer array

### DIFF
--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -145,6 +145,7 @@ export default function Scene({sceneModel, lookatManager}) {
           if (child.userData.origIndexBuffer){
             child.geometry.setIndex(child.userData.clippedIndexGeometry);
             child.geometry.boundsTree = child.userData.lastBoundsTree;
+            child.userData.clippedIndexGeometry.dispose();
           }
         }
       })


### PR DESCRIPTION
Overall, selecting dofferent models, changing trait distance was freezing app, this was due to memory leak.

Correctly disposing temporary index buffer array that was set to detect cull hidden faces, fix this

fix for #50 