### PR TITLE
Improve Optimizer 4

### DIFF
--- a/src/components/ExportMenu.jsx
+++ b/src/components/ExportMenu.jsx
@@ -46,8 +46,8 @@ export const ExportMenu = ({getFaceScreenshot}) => {
         className={styles.button}
         onClick={() => {
           const screenshot = getFaceScreenshot();
-
-          downloadVRMWithAvatar(model, avatar, name, screenshot, 4096,templateInfo.exportScale||1, true, templateInfo.vrmMeta,false)
+          const options = {screenshot:screenshot, atlasSize: 4096, scale:templateInfo.exportScale||1, isVrm0:true, vrmMeta:templateInfo.vrmMeta,createTextureAtlas:false}
+          downloadVRMWithAvatar(model, avatar, name, options)
         }}
       />
       <CustomButton
@@ -58,9 +58,8 @@ export const ExportMenu = ({getFaceScreenshot}) => {
         className={styles.button}
         onClick={() => {
           const screenshot = getFaceScreenshot();
-          console.log(model);
-          console.log(avatar)
-          downloadVRMWithAvatar(model, avatar, name, screenshot, 4096,templateInfo.exportScale||1, true, templateInfo.vrmMeta,true)
+          const options = {screenshot:screenshot, atlasSize: 4096, scale:templateInfo.exportScale||1, isVrm0:true, vrmMeta:templateInfo.vrmMeta,createTextureAtlas:true}
+          downloadVRMWithAvatar(model, avatar, name, options)
         }}
       />
     </React.Fragment>

--- a/src/components/ModelInformation.jsx
+++ b/src/components/ModelInformation.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import styles from "./ModelInformation.module.css"
 import MenuTitle from "./MenuTitle"
 import { findChildrenByType } from "../library/utils";
-import { getAsArray } from "../library/utils";
+import { getAsArray, getMaterialsSortedByArray } from "../library/utils";
 
 export default function ModelInformation({currentVRM}){
     const [meshQty, setMeshQty] = useState(0);
@@ -24,46 +24,17 @@ export default function ModelInformation({currentVRM}){
             setMeshQty(meshes.length)
             setSkinnedMeshQty(skinnedMesh.length)
 
-
             const allMeshes =  meshes.concat(skinnedMesh);
-            let stdMaterialCount = 0;
-            let stdTranspMaterialCount = 0;
-            let stdCutoutMaterialCount = 0;
 
-            let shaderMaterialCount = 0;
-            let shaderTranspMaterialCount = 0;
-            let shaderTCutoutMaterialCount = 0;
-            allMeshes.forEach(mesh => {
-                const mats = getAsArray(mesh.material);
-                mats.forEach(mat => {
-                    if (mat.type == "ShaderMaterial"){
-                        if (mat.transparent == true)
-                            shaderTranspMaterialCount++
-                        else if (mat.uniforms.alphaTest.value != 0)
-                            shaderTCutoutMaterialCount++
-                        else
-                            shaderMaterialCount++;
-                    }
-                    else{
-                        if (mat.transparent == true)
-                            stdTranspMaterialCount++
-                        else if (mat.alphaTest != 0)
-                            stdCutoutMaterialCount++
-                        else
-                            stdMaterialCount++;
-                            
-                    }
-                    // if (mat.type == "MeshStandardMaterial")
-                    //     stdMaterialCount++;
-                });
-            });
-            setStandardMaterialQty(stdMaterialCount);
-            setStandardTranspMaterialQty(stdTranspMaterialCount);
-            setStandardCutoutMaterialQty(stdCutoutMaterialCount);
+            const {stdMats,stdCutoutpMats,stdTranspMats,mToonMats,mToonCutoutMats,mToonTranspMats} = getMaterialsSortedByArray(allMeshes);
 
-            setVrmMaterialQty(shaderMaterialCount);
-            setVrmTranspMaterialQty(shaderTranspMaterialCount);
-            setVrmCutoutMaterialQty(shaderTCutoutMaterialCount);
+            setStandardMaterialQty(stdMats.length);
+            setStandardTranspMaterialQty(stdTranspMats.length);
+            setStandardCutoutMaterialQty(stdCutoutpMats.length);
+
+            setVrmMaterialQty(mToonMats.length);
+            setVrmTranspMaterialQty(mToonTranspMats.length);
+            setVrmCutoutMaterialQty(mToonCutoutMats.length);
         }
     }, [currentVRM])
 

--- a/src/components/ModelInformation.module.css
+++ b/src/components/ModelInformation.module.css
@@ -10,6 +10,7 @@
   background: rgba(5, 11, 14, 0.8);
   z-index: 1000;
   user-select: none;
+  text-align: right;
 }
 
 .scrollContainer {
@@ -21,6 +22,7 @@
   margin: 30px;
   height: -webkit-calc(100% - 40px);
   height: calc(100% - 40px);
+  
 }
 
 .traitInfoTitle {
@@ -30,6 +32,8 @@
   font-size: 16px;
   word-spacing: 2px;
   margin-bottom: 10px;
+  text-align: right;
+  
 }
 .traitInfoText {
   color: rgb(179, 179, 179);
@@ -38,6 +42,7 @@
   font-size: 16px;
   word-spacing: 2px;
   margin-bottom: 30px;
+  text-align: right;
 }
 .input-box {
   width: 60px; /* Adjust as needed */

--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -165,7 +165,6 @@ export default class VRMExporterv0 {
         const outputSamplers = toOutputSamplers(outputImages);
         const outputTextures = toOutputTextures(outputImages);
         const outputMaterials = toOutputMaterials(uniqueMaterials, images);
-        console.log("outputmat", outputMaterials);
         const rootNode = avatar.children.filter((child) => child.children.length > 0 &&
             child.children[0].type === VRMObjectType.Bone)[0];
         const nodes = getNodes(rootNode).filter((node) => node.name !== SPRINGBONE_COLLIDER_NAME);
@@ -996,11 +995,10 @@ const toOutputMaterials = (uniqueMaterials, images) => {
       let VRMC_materials_mtoon = null;
       
       material = material.userData.vrmMaterial?material.userData.vrmMaterial:material;
-      console.log(material);
       if (material.type === "ShaderMaterial") {
-          VRMC_materials_mtoon = material.userData.gltfExtensions.VRMC_materials_mtoon;
+          //VRMC_materials_mtoon = material.userData.gltfExtensions.VRMC_materials_mtoon;
+          VRMC_materials_mtoon = {};
           VRMC_materials_mtoon.shadeMultiplyTexture = {index:images.map((image) => image.name).indexOf(material.uniforms.shadeMultiplyTexture.name)};
-
           const mtoonMaterial = material;
           baseColor = mtoonMaterial.color ? [
                   1,

--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -165,6 +165,7 @@ export default class VRMExporterv0 {
         const outputSamplers = toOutputSamplers(outputImages);
         const outputTextures = toOutputTextures(outputImages);
         const outputMaterials = toOutputMaterials(uniqueMaterials, images);
+        console.log("outputmat", outputMaterials);
         const rootNode = avatar.children.filter((child) => child.children.length > 0 &&
             child.children[0].type === VRMObjectType.Bone)[0];
         const nodes = getNodes(rootNode).filter((node) => node.name !== SPRINGBONE_COLLIDER_NAME);
@@ -395,7 +396,7 @@ export default class VRMExporterv0 {
         //     upperLegTwist: humanoid.humanDescription.upperLegTwist,
         // };
         
-        const materialProperties = [{
+        const vrmMaterialProperties = {
             floatProperties : {
                 // _BlendMode : 0, 
                 // _BumpScale : 1, 
@@ -430,7 +431,7 @@ export default class VRMExporterv0 {
                 MTOON_OUTLINE_COLOR_FIXED : true, 
                 MTOON_OUTLINE_WIDTH_WORLD : true
             }, 
-            name : "CombinedMat", 
+            name : "VRMCombinedMat", 
             renderQueue : 2000, 
             shader : "VRM/MToon", 
             tagMap : {
@@ -456,8 +457,26 @@ export default class VRMExporterv0 {
                 // _SphereAdd : [0, 0, 1, 1], 
                 // _UvAnimMaskTexture : [0, 0, 1, 1]
             }
-        }]
+        }
 
+        const stdMaterialProperties ={
+            name : "STDCombinedMat", 
+            shader : "VRM_USE_GLTFSHADER", 
+        }
+
+        const materialProperties = []
+        uniqueMaterials.forEach(mat => {
+            if (mat.type == "ShaderMaterial"){
+                materialProperties.push(
+                    materialProperties.push(Object.assign({}, vrmMaterialProperties))
+                )
+            }
+            else{
+                materialProperties.push(
+                    materialProperties.push(Object.assign({}, stdMaterialProperties))
+                )
+            }
+        });
         //const outputVrmMeta = ToOutputVRMMeta(vrmMeta, icon, outputImages);
         const outputVrmMeta = vrmMeta;
 
@@ -624,6 +643,8 @@ export default class VRMExporterv0 {
 
         const outputScenes = toOutputScenes(avatar, outputNodes);
 
+
+
         const outputData = {
             accessors: outputAccessors,
             asset: exporterInfo,
@@ -668,7 +689,6 @@ export default class VRMExporterv0 {
             skins: outputSkins,
             textures: outputTextures,
         };
-        console.log(outputData)
         const jsonChunk = new GlbChunk(parseString2Binary(JSON.stringify(outputData, undefined, 2)), "JSON");
         const binaryChunk = new GlbChunk(concatBinary(bufferViews.map((buf) => buf.buffer)), "BIN\x00");
         const fileData = concatBinary([jsonChunk.buffer, binaryChunk.buffer]);
@@ -976,6 +996,7 @@ const toOutputMaterials = (uniqueMaterials, images) => {
       let VRMC_materials_mtoon = null;
       
       material = material.userData.vrmMaterial?material.userData.vrmMaterial:material;
+      console.log(material);
       if (material.type === "ShaderMaterial") {
           VRMC_materials_mtoon = material.userData.gltfExtensions.VRMC_materials_mtoon;
           VRMC_materials_mtoon.shadeMultiplyTexture = {index:images.map((image) => image.name).indexOf(material.uniforms.shadeMultiplyTexture.name)};

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -242,7 +242,7 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
   ResetRenderTextureContainer();
 
   const ATLAS_SIZE_PX = atlasSize;
-  const IMAGE_NAMES = ["diffuse", "orm"];
+  const IMAGE_NAMES = mtoon ? ["diffuse"] : ["diffuse", "orm"];// not using normal texture for now
   const bakeObjects = [];
   // save if there is vrm data
   let vrmMaterial = null;
@@ -452,14 +452,19 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
       map: textures["diffuse"],
       roughnessMap: textures["orm"],
       metalnessMap:  textures["orm"],
+      normalMap: textures["normal"],
       transparent: transparentMaterial
     });
+
     if (transparentTexture){
       material.alphaTest = 0.5;
     }
     material.name = "standard_" + materialPostName;
 
-    material.roughnessMap.name = material.name + "_orm";
+    if (material.roughnessMap != null)
+      material.roughnessMap.name = material.name + "_orm";
+    if (material.normalMap != null)
+      material.normalMap.name = material.name + "_normal";
   }
   // xxxreturn material with textures, dont return uvs nor textures
   return { bakeObjects, material };

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -233,26 +233,8 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize =
   // save material color from here
 
   meshes.forEach((mesh) => {
-    //console.log(mesh.geometry.attributes.uv)
-    
-    const boneName = mesh.type == "Mesh" ? mesh.parent.name:null;
-    const originalGlobalPosition = new THREE.Vector3();
-    const originalGlobalScale = new THREE.Vector3();
-    mesh.getWorldPosition(originalGlobalPosition);
-    mesh.getWorldScale(originalGlobalScale)
+
     mesh = mesh.clone();
-
-    if (mesh.type == "Mesh"){
-      const rotationMatrix = new THREE.Matrix4();
-      const rotation = new THREE.Quaternion()
-      mesh.getWorldQuaternion(rotation);
-      rotationMatrix.makeRotationFromQuaternion(rotation);
-
-      mesh.userData.boneName = boneName;
-      mesh.userData.globalPosition = originalGlobalPosition;
-      mesh.userData.globalScale = originalGlobalScale;
-      mesh.userData.globalRotationMatrix = rotationMatrix;
-    }
     
     const material = mesh.material.length == null ? mesh.material : mesh.material[0];
     // use the vrmData of the first material, and call it atlas if it exists

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -91,6 +91,7 @@ function createContext({ width, height, transparent }) {
   return context;
 }
 function getTextureImage(material, textureName) {
+
   // material can come in arrays or single values, in case of ccoming in array take the first one
   material = material.length == null ? material : material[0];
   return material[textureName] && material[textureName].image;
@@ -241,7 +242,7 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
   ResetRenderTextureContainer();
 
   const ATLAS_SIZE_PX = atlasSize;
-  const IMAGE_NAMES = ["diffuse"];
+  const IMAGE_NAMES = ["diffuse", "orm"];
   const bakeObjects = [];
   // save if there is vrm data
   let vrmMaterial = null;
@@ -256,7 +257,6 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
     // use the vrmData of the first material, and call it atlas if it exists
     if (mtoon && vrmMaterial == null && material.type == "ShaderMaterial") {
       vrmMaterial = material.clone();
-      console.log("vrmmat", vrmMaterial)
     }
 
     // check if bakeObjects objects that contain the material property with value of mesh.material
@@ -340,7 +340,6 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
 
   bakeObjects.forEach((bakeObject) => {
     const { material, mesh } = bakeObject;
-    console.log(material);
     const { min, max } = uvs.get(mesh);
     IMAGE_NAMES.forEach((name) => {
       const context = contexts[name];
@@ -445,21 +444,22 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
     // uniform color is not defined, remove or check why
     material.userData.shadeTexture = textures["uniformColor"];
     material.name = "mToon_" + materialPostName;
-    console.log("Temporal hack, we need to assign with texture name, not material name")
     material.map.name = material.name;
   }
   else{
     // xxx set textures and colors
     material = new THREE.MeshStandardMaterial({
       map: textures["diffuse"],
+      roughnessMap: textures["orm"],
+      metalnessMap:  textures["orm"],
       transparent: transparentMaterial
     });
     if (transparentTexture){
       material.alphaTest = 0.5;
     }
-
     material.name = "standard_" + materialPostName;
-    console.log(material.name);
+
+    material.roughnessMap.name = material.name + "_orm";
   }
   // xxxreturn material with textures, dont return uvs nor textures
   return { bakeObjects, material };

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -410,28 +410,43 @@ export const createTextureAtlasBrowser = async ({ backColor, meshes, atlasSize, 
       IMAGE_NAMES.map(async (name) => {
         const texture = new THREE.Texture(contexts[name].canvas)
         texture.flipY = false;
-
+        //const matName = (mtoon ? "mtoon_" : "standard") + (transparentMaterial ? "transp_":"opaque_");
+        //texture.name = matName + name;
         return [name, texture];
       })
     )
   );
 
   let material;
-  console.log("CONTRINUE HERE");
   const materialPostName = transparentMaterial ? "transparent":"opaque"
   if (mtoon){
     // xxx set textures and colors
-    material = new MToonMaterial();
-    material.uniforms.map = textures["diffuse"];
-    material.uniforms.shadeMultiplyTexture = textures["diffuse"];
+    // save material as standard material
+    material = new THREE.MeshStandardMaterial({
+      map: textures["diffuse"],
+      transparent: transparentMaterial
+    });
+    if (transparentTexture){
+      material.alphaTest = 0.5;
+    }
 
-    // is this necessary?, or what should i include from this section?
-    material.userData.vrmMaterial = material;
+    // but also store a vrm material that will hold the extension information
+    if (vrmMaterial == null){
+      vrmMaterial = new MToonMaterial();
+    }
+
+    vrmMaterial.uniforms.map = textures["diffuse"];
+    vrmMaterial.uniforms.shadeMultiplyTexture = textures["diffuse"];
+    vrmMaterial.alphaTest = 0.5;
+
+    
+    material.userData.vrmMaterial = vrmMaterial;
 
     // uniform color is not defined, remove or check why
     material.userData.shadeTexture = textures["uniformColor"];
-
     material.name = "mToon_" + materialPostName;
+    console.log("Temporal hack, we need to assign with texture name, not material name")
+    material.map.name = material.name;
   }
   else{
     // xxx set textures and colors

--- a/src/library/download-utils.js
+++ b/src/library/download-utils.js
@@ -94,24 +94,28 @@ async function getGLBData(model, options){
 
 
 
-//required: model, name, vrmData
-//parameters {screenshot, scale, isVrm0, vrmMeta, createTextureAtlas}
+/**
+ * Downloads a VRM model with specified options.
+ *
+ * @param {Object} model - The 3D model object.
+ * @param {Object} vrmData - The VRM data for the model.
+ * @param {string} fileName - The name of the file to be downloaded.
+ * @param {Object} options - Additional options for the download.
+ * @param {Object} options.screenshot - An optional screenshot for the model.
+ * @param {number} options.mToonAtlasSize - Atlas size for opaque parts when using MToon material.
+ * @param {number} options.mToonAtlasSizeTransp - Atlas size for transparent parts when using MToon material.
+ * @param {number} options.stdAtlasSize - Atlas size for opaque parts when using standard materials.
+ * @param {number} options.stdAtlasSizeTransp - Atlas size for transparent parts when using standard materials.
+ * @param {boolean} options.exportMtoonAtlas - Whether to export the MToon material atlas.
+ * @param {boolean} options.exportStdAtlas - Whether to export the standard material atlas.
+ * @param {number} options.scale - Scaling factor for the model.
+ * @param {boolean} options.isVrm0 - Whether the VRM version is 0 (true) or 1 (false).
+ * @param {Object} options.vrmMeta - Additional metadata for the VRM model.
+ * @param {boolean} options.createTextureAtlas - Whether to create a texture atlas.
+ * @param {boolean} options.optimized - Whether to optimize the VRM model.
+ */
 export async function downloadVRM(model,vrmData,fileName, options){
-    const {
-      screenshot = null,
-      //transparentColor = new THREE.Color(1,1,1) ,
-      mToonAtlasSize = 4096, 
-      mToonAtlasSizeTransp = 4096, 
-      stdAtlasSize = 4096, 
-      stdAtlasSizeTransp = 4096,
-      exportMtoonAtlas = false, 
-      exportStdAtlas = true,
-      scale = 1,
-      isVrm0 = false,
-      vrmMeta = null,
-      createTextureAtlas = true,
-      optimized=true
-    } = options;
+
 
     const avatar = {_optimized:{vrm:vrmData}}
     downloadVRMWithAvatar(model, avatar, fileName, options)

--- a/src/library/download-utils.js
+++ b/src/library/download-utils.js
@@ -68,7 +68,7 @@ function getOptimizedGLB(avatarToDownload, atlasSize, scale = 1, isVrm0 = false,
       return combine({
         transparentColor: new Color(1,1,1),
         avatar: avatarToDownloadClone,
-        atlasSize,
+        mToonAtlasSize: atlasSize,
         scale
       }, isVrm0)
     }

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -239,8 +239,10 @@ function mapOldBoneIndexToNew(oldBoneIndex, oldSkeleton, newSkeleton) {
     }
   }
 
-export async function combineNoAtlas({ avatar, scale = 1 }, isVrm0 = false) {
+export async function combineNoAtlas(avatar, options) {
     
+    const { scale, isVrm0 } = options
+
     const clonedMeshes = [];
     const material = [];
 
@@ -430,16 +432,19 @@ function createSkinnedMeshFromMesh(baseSkeleton, mesh){
     return skinnedMesh;
 }
 
-export async function combine({ 
-    transparentColor, 
-    avatar, 
-    scale = 1, 
-    mToonAtlasSize = 4096, 
-    mToonAtlasSizeTransp = 4096, 
-    stdAtlasSize = 4096, 
-    stdAtlasSizeTransp = 4096,
-    exportMtoonAtlas = false, 
-    exportStdAtlas = true }, isVrm0 = false) {
+export async function combine(avatar, options) {
+
+    const {
+        transparentColor = new THREE.Color(1,1,1),
+        mToonAtlasSize = 4096, 
+        mToonAtlasSizeTransp = 4096, 
+        stdAtlasSize = 4096, 
+        stdAtlasSizeTransp = 4096,
+        exportMtoonAtlas = false, 
+        exportStdAtlas = true,
+        isVrm0 = false,
+        scale = 1,
+    } = options;
 
     // convert meshes to skinned meshes first
     const cloneNonSkinnedMeshes = findChildrenByType(avatar, ["Mesh"]);

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -494,7 +494,6 @@ export async function combine(avatar, options) {
         const arr = meshData.meshArray;
         if (arr.length > 0)
         {        
-            console.log(arr);
             const { bakeObjects, material } = 
                 await createTextureAtlas({ transparentColor, atlasSize:meshData.size, meshes: arr, mtoon:meshData.isMtoon, transparentMaterial:meshData.transparentMaterial, transparentTexture:requiresTransparency});
                 const meshes = bakeObjects.map((bakeObject) => bakeObject.mesh);
@@ -592,7 +591,6 @@ export async function combine(avatar, options) {
         }
     }
     group.add(newSkeleton.bones[0]);
-    console.log(group);
     return group;
 }
 

--- a/src/library/utils.js
+++ b/src/library/utils.js
@@ -115,6 +115,43 @@ export const cullHiddenMeshes = (avatar) => {
   CullHiddenFaces(models)
 }
 
+export function getMeshesSortedByMaterialArray(meshes){
+  const stdMesh = [];
+  const stdTranspMesh = [];
+  const mToonMesh = [];
+  const mToonTranspMesh = [];
+  let requiresTransparency = false;
+
+  meshes.forEach(mesh => {
+    const mats = getAsArray(mesh.material);
+    const mat = mats[0];
+    
+    if (mat.type == "ShaderMaterial"){
+        if (mat.transparent == true){
+          mToonTranspMesh.push(mesh);
+          requiresTransparency = true;
+        }
+        else{
+          mToonMesh.push(mesh);
+          if (mat.uniforms.alphaTest.value != 0)
+            requiresTransparency = true
+        }
+    }
+    else{
+        if (mat.transparent == true){
+          stdTranspMesh.push(mesh);
+          requiresTransparency = true;
+        }
+        else{
+          stdMesh.push(mesh); 
+          if (mat.alphaTest != 0)
+            requiresTransparency = true;
+        }
+    }
+  });
+  return {stdMesh, stdTranspMesh, mToonMesh, mToonTranspMesh, requiresTransparency}
+}
+
 export function getMaterialsSortedByArray (meshes){
   const stdMats = [];
   const stdCutoutpMats = [];
@@ -124,8 +161,8 @@ export function getMaterialsSortedByArray (meshes){
   const mToonTranspMats = [];
 
   meshes.forEach(mesh => {
-  const mats = getAsArray(mesh.material);
-  mats.forEach(mat => {
+    const mats = getAsArray(mesh.material);
+    mats.forEach(mat => {
       if (mat.type == "ShaderMaterial"){
           if (mat.transparent == true)
             mToonTranspMats.push(mat);
@@ -599,11 +636,11 @@ export function findChildrenByType(root, types) {
     predicate: (o) => getAsArray(types).includes(o.type),
   });
 }
-export function getAvatarData (avatarModel, modelName, atlasMaterial, vrmMeta){
+export function getAvatarData (avatarModel, modelName, vrmMeta){
   const skinnedMeshes = findChildrenByType(avatarModel, "SkinnedMesh")
   return{
     humanBones:getHumanoidByBoneNames(skinnedMeshes[0]),
-    materials : atlasMaterial ? [avatarModel.userData.atlasMaterial] : avatarModel.userData.atlasMaterial,
+    materials : avatarModel.userData.atlasMaterial,
     meta : getVRMMeta(modelName, vrmMeta)
   }
 

--- a/src/library/utils.js
+++ b/src/library/utils.js
@@ -115,6 +115,41 @@ export const cullHiddenMeshes = (avatar) => {
   CullHiddenFaces(models)
 }
 
+export function getMaterialsSortedByArray (meshes){
+  const stdMats = [];
+  const stdCutoutpMats = [];
+  const stdTranspMats = [];
+  const mToonMats = [];
+  const mToonCutoutMats = [];
+  const mToonTranspMats = [];
+
+  meshes.forEach(mesh => {
+  const mats = getAsArray(mesh.material);
+  mats.forEach(mat => {
+      if (mat.type == "ShaderMaterial"){
+          if (mat.transparent == true)
+            mToonTranspMats.push(mat);
+          else if (mat.uniforms.alphaTest.value != 0)
+            mToonCutoutMats.push(mat);
+          else
+            mToonMats.push(mat);
+      }
+      else{
+          if (mat.transparent == true)
+            stdTranspMats.push(mat);
+          else if (mat.alphaTest != 0)
+            stdCutoutpMats.push(mat);
+          else
+            stdMats.push(mat);
+              
+      }
+    });
+  });
+
+
+  return { stdMats, stdCutoutpMats, stdTranspMats , mToonMats, mToonCutoutMats , mToonTranspMats }
+}
+
 export async function getModelFromScene(avatarScene, format = 'glb', skinColor = new THREE.Color(1, 1, 1), scale = 1) {
   if (format && format === 'glb') {
     const exporter = new GLTFExporter();

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -30,6 +30,8 @@ function Optimizer({
   const [atlasMtoon, setAtlasMtoon] = useState(6);
   const [atlasMtoonTransp, setAtlasMtoonTransp] = useState(6);
   const [downloadOnDrop, setDownloadOnDrop] = useState(false)
+  const [currentOption, setCurrentOption] = useState(0);
+  const [options] = useState(["Merge to Standard", "Merge to MToon", "Keep Both"])
 
   const { playSound } = React.useContext(SoundContext)
   const { isMute } = React.useContext(AudioContext)
@@ -43,9 +45,6 @@ function Optimizer({
     const vrmData = currentVRM.userData.vrm
     downloadVRM(model, vrmData,nameVRM + "_merged",null,getAtlasSize(atlasMtoon),1,true, null, true)
   }
-  useEffect(()=>{
-    console.log("onlaod");
-  },[])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -84,6 +83,25 @@ function Optimizer({
     setDownloadOnDrop(event.target.checked);
   }
 
+  const prevOption = () => {
+    console.log(currentOption);
+    console.log(options.length);
+    console.log(options)
+    if (currentOption <= 0)
+      setCurrentOption(options.length-1);
+    else
+      setCurrentOption(currentOption - 1)
+  }
+
+  const nextOption = () => {
+
+    if (currentOption >= options.length-1)
+      setCurrentOption(0);
+    else
+      setCurrentOption(currentOption + 1);
+    
+  }
+
   const getAtlasSize = (value) =>{
     switch (value){
       case 1:
@@ -108,8 +126,6 @@ function Optimizer({
   }
 
   const handleChangeAtlasSize = async (event, type) => {
-    console.log(event.target);
-    console.log(type);
     let val = parseInt(event.target.value);
     if (val > 8)
       val = 8;
@@ -133,9 +149,7 @@ function Optimizer({
           break;
       }
     }
-    setAtlasSize(val)
-    
-    
+    setAtlasSize(val) 
   }
 
   const handleVRMDrop = async (file) =>{
@@ -171,26 +185,51 @@ function Optimizer({
       <div className={styles["InformationContainerPos"]}>
         <MenuTitle title="Optimizer Options" width={180} left={20}/>
         <div className={styles["scrollContainer"]}>
-          <div className={styles["traitInfoTitle"]}>
-              Standard Atlas Size
+
+        <div className={styles["traitInfoTitle"]}>
+              Merge Atlas Type
           </div>
           <br />
-          <div className={styles["traitInfoText"]}>
-              Opaque: {getAtlasSize(atlasStd) + " x " + getAtlasSize(atlasStd)}
+          <div className={styles["flexSelect"]}>
+              <div 
+                  className={`${styles["arrow-button"]} ${styles["left-button"]}`}
+                  onClick={prevOption}
+              ></div>
+              <div className={styles["traitInfoText"]} style={{ marginBottom: '0' }}>{options[currentOption]}</div>
+              <div 
+              //`${styles.class1} ${styles.class2}`
+                  className={`${styles["arrow-button"]} ${styles["right-button"]}`}
+                  onClick={nextOption}
+              ></div>
           </div>
+          <br /><br /><br />
 
-            <Slider value = {atlasStd} onChange={(value) => handleChangeAtlasSize(value, 'standard opaque')} min={1} max={8} step={1}/>
-            <br/>
-            <div className={styles["traitInfoText"]}>
-              Transparent: {getAtlasSize(atlasStdTransp) + " x " + getAtlasSize(atlasStdTransp)}
-          </div>
-            <Slider value = {atlasStdTransp} onChange={(value) => handleChangeAtlasSize(value, 'standard transparent')} min={1} max={8} step={1}/>
-            <br/> <br/> <br/>
-
+          {(currentOption === 0 || currentOption == 2)&&(
+            <>
             <div className={styles["traitInfoTitle"]}>
-              MToon Atlas Size
-          </div>
-          <br />
+                Standard Atlas Size
+            </div>
+            <br />
+            <div className={styles["traitInfoText"]}>
+                Opaque: {getAtlasSize(atlasStd) + " x " + getAtlasSize(atlasStd)}
+            </div>
+
+              <Slider value = {atlasStd} onChange={(value) => handleChangeAtlasSize(value, 'standard opaque')} min={1} max={8} step={1}/>
+              <br/>
+              <div className={styles["traitInfoText"]}>
+                Transparent: {getAtlasSize(atlasStdTransp) + " x " + getAtlasSize(atlasStdTransp)}
+            </div>
+              <Slider value = {atlasStdTransp} onChange={(value) => handleChangeAtlasSize(value, 'standard transparent')} min={1} max={8} step={1}/>
+              <br/> <br/> <br/>
+            </>
+          )}
+
+          {(currentOption === 1 || currentOption == 2)&&(
+            <>
+            <div className={styles["traitInfoTitle"]}>
+                MToon Atlas Size
+            </div>
+            <br />
           <div className={styles["traitInfoText"]}>
               Opaque: {getAtlasSize(atlasMtoon) + " x " + getAtlasSize(atlasMtoon)}
           </div>
@@ -202,10 +241,12 @@ function Optimizer({
           </div>
             <Slider value = {atlasMtoonTransp} onChange={(value) => handleChangeAtlasSize(value, 'mtoon transparent')} min={1} max={8} step={1}/>
             <br/> <br/> <br/>
-
+            </>
+          )}
           <div className={styles["traitInfoTitle"]}>
               Drag Drop - Download
           </div>
+          
 
           <div className={styles["traitInfoText"]}>
             <div className={styles["checkboxHolder"]}>

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -13,6 +13,7 @@ import { downloadVRM } from "../library/download-utils"
 import ModelInformation from "../components/ModelInformation"
 import MenuTitle from "../components/MenuTitle"
 import Slider from "../components/Slider"
+import { local } from "../library/store"
 
 function Optimizer({
   animationManager,
@@ -25,12 +26,12 @@ function Optimizer({
   const [currentVRM, setCurrentVRM] = useState(null);
   const [lastVRM, setLastVRM] = useState(null);
   const [nameVRM, setNameVRM] = useState("");
-  const [atlasStd, setAtlasStd] = useState(6);
-  const [atlasStdTransp, setAtlasStdTransp] = useState(6);
-  const [atlasMtoon, setAtlasMtoon] = useState(6);
-  const [atlasMtoonTransp, setAtlasMtoonTransp] = useState(6);
+  const [atlasStd, setAtlasStd] = useState(local["optimizer_atlas_std_size"] || 6);
+  const [atlasStdTransp, setAtlasStdTransp] = useState(local["optimizer_atlas_std_transp_size"] || 6);
+  const [atlasMtoon, setAtlasMtoon] = useState(local["optimizer_atlas_mtoon_size"] || 6);
+  const [atlasMtoonTransp, setAtlasMtoonTransp] = useState(local["optimizer_atlas_mtoon_transp_size"] || 6);
   const [downloadOnDrop, setDownloadOnDrop] = useState(false)
-  const [currentOption, setCurrentOption] = useState(0);
+  const [currentOption, setCurrentOption] = useState(local["optimizer_sel_option"] || 0);
   const [options] = useState(["Merge to Standard", "Merge to MToon", "Keep Both"])
 
   const { playSound } = React.useContext(SoundContext)
@@ -95,19 +96,25 @@ function Optimizer({
   }
 
   const prevOption = () => {
+    let cur = currentOption;
     if (currentOption <= 0)
-      setCurrentOption(options.length-1);
+      cur = options.length-1
     else
-      setCurrentOption(currentOption - 1)
+      cur -= 1
+
+    setCurrentOption(cur);
+    local["optimizer_sel_option"] = cur;
   }
 
   const nextOption = () => {
-
-    if (currentOption >= options.length-1)
-      setCurrentOption(0);
+    let cur = currentOption;
+    if (currentOption >= options.length - 1)
+      cur = 0;
     else
-      setCurrentOption(currentOption + 1);
-    
+      cur +=1;
+
+    setCurrentOption(cur);
+    local["optimizer_sel_option"] = cur;
   }
 
   const getAtlasSize = (value) =>{
@@ -145,15 +152,19 @@ function Optimizer({
         case 'standard opaque':
           // save to user prefs
           setAtlasStd(size);
+          local["optimizer_atlas_std_size"]  = size;
           break;
         case 'standard transparent':
           setAtlasStdTransp(size);
+          local["optimizer_atlas_std_transp_size"] = size;
           break;
         case 'mtoon opaque':
           setAtlasMtoon(size);
+          local["optimizer_atlas_mtoon_size"] = size;
           break;
         case 'mtoon transparent':
           setAtlasMtoonTransp(size);
+          local["optimizer_atlas_mtoon_transp_size"] = size;
           break;
       }
     }

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -84,9 +84,6 @@ function Optimizer({
   }
 
   const prevOption = () => {
-    console.log(currentOption);
-    console.log(options.length);
-    console.log(options)
     if (currentOption <= 0)
       setCurrentOption(options.length-1);
     else

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -43,7 +43,12 @@ function Optimizer({
 
   const download = () => {
     const vrmData = currentVRM.userData.vrm
-    downloadVRM(model, vrmData,nameVRM + "_merged",null,getAtlasSize(atlasMtoon),1,true, null, true)
+    const options = {
+      atlasSize : 4096,
+      isVrm0 : true,
+      createTextureAtlas : true,
+    }
+    downloadVRM(model, vrmData,nameVRM + "_merged", options)
   }
 
   useEffect(() => {

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -25,8 +25,10 @@ function Optimizer({
   const [currentVRM, setCurrentVRM] = useState(null);
   const [lastVRM, setLastVRM] = useState(null);
   const [nameVRM, setNameVRM] = useState("");
-  const [atlasSize, setAtlasSize] = useState(4096);
-  const [atlasValue, setAtlasValue] = useState(6);
+  const [atlasStd, setAtlasStd] = useState(6);
+  const [atlasStdTransp, setAtlasStdTransp] = useState(6);
+  const [atlasMtoon, setAtlasMtoon] = useState(6);
+  const [atlasMtoonTransp, setAtlasMtoonTransp] = useState(6);
   const [downloadOnDrop, setDownloadOnDrop] = useState(false)
 
   const { playSound } = React.useContext(SoundContext)
@@ -39,8 +41,11 @@ function Optimizer({
 
   const download = () => {
     const vrmData = currentVRM.userData.vrm
-    downloadVRM(model, vrmData,nameVRM + "_merged",null,atlasSize,1,true, null, true)
+    downloadVRM(model, vrmData,nameVRM + "_merged",null,getAtlasSize(atlasMtoon),1,true, null, true)
   }
+  useEffect(()=>{
+    console.log("onlaod");
+  },[])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -79,43 +84,57 @@ function Optimizer({
     setDownloadOnDrop(event.target.checked);
   }
 
-  const handleChangeAtlasSize = async (event) => {
-    const val = parseInt(event.target.value);
-    if (val > 8)
-      setAtlasValue(8)
-    else if (val < 0)
-      setAtlasValue(0)
-    else 
-      setAtlasValue(val)
-
-    switch (val){
+  const getAtlasSize = (value) =>{
+    switch (value){
       case 1:
-        setAtlasSize(128);
-        break;
+        return 128;
       case 2:
-        setAtlasSize(256);
-        break;
+        return 256;
       case 3:
-        setAtlasSize(512);
-        break;
+        return 512;
       case 4:
-        setAtlasSize(1024);
-        break;
+        return 1024;
       case 5:
-        setAtlasSize(2048);
-        break;
+        return 2048;
       case 6:
-        setAtlasSize(4096);
-        break;
+        return 4096;
       case 7:
-        setAtlasSize(8192);
-        break;
+        return 8192;
       case 8:
-        setAtlasSize(16384);
-        break;
+        return 16384;
       default:
-        break;
+        return 4096;
     }
+  }
+
+  const handleChangeAtlasSize = async (event, type) => {
+    console.log(event.target);
+    console.log(type);
+    let val = parseInt(event.target.value);
+    if (val > 8)
+      val = 8;
+    else if (val < 0)
+      val = 0;
+
+    const setAtlasSize = (size) => {
+      switch (type){
+        case 'standard opaque':
+          // save to user prefs
+          setAtlasStd(size);
+          break;
+        case 'standard transparent':
+          setAtlasStdTransp(size);
+          break;
+        case 'mtoon opaque':
+          setAtlasMtoon(size);
+          break;
+        case 'mtoon transparent':
+          setAtlasMtoonTransp(size);
+          break;
+      }
+    }
+    setAtlasSize(val)
+    
     
   }
 
@@ -124,16 +143,9 @@ function Optimizer({
     const vrm = await loadVRM(path);
     const name = getFileNameWithoutExtension(file.name);
 
-    // if (currentVRM != null){
-    //   disposeVRM(currentVRM);
-    // }
     setNameVRM(name);
     setCurrentVRM(vrm);
-
-    
-
-    //downloadVRM(model, vrmData,nameVRM + "_merged",null,atlasSize,1,true, null, true)
-    //setUploadVRMURL(path);
+    console.log(vrm)
   }
 
   const handleFilesDrop = async(files) => {
@@ -160,11 +172,37 @@ function Optimizer({
         <MenuTitle title="Optimizer Options" width={180} left={20}/>
         <div className={styles["scrollContainer"]}>
           <div className={styles["traitInfoTitle"]}>
-              Atlas size: {atlasSize + " x " + atlasSize}
+              Standard Atlas Size
+          </div>
+          <br />
+          <div className={styles["traitInfoText"]}>
+              Opaque: {getAtlasSize(atlasStd) + " x " + getAtlasSize(atlasStd)}
           </div>
 
-            <Slider  value={atlasValue} onChange={handleChangeAtlasSize} min={1} max={8} step={1}/>
+            <Slider value = {atlasStd} onChange={(value) => handleChangeAtlasSize(value, 'standard opaque')} min={1} max={8} step={1}/>
             <br/>
+            <div className={styles["traitInfoText"]}>
+              Transparent: {getAtlasSize(atlasStdTransp) + " x " + getAtlasSize(atlasStdTransp)}
+          </div>
+            <Slider value = {atlasStdTransp} onChange={(value) => handleChangeAtlasSize(value, 'standard transparent')} min={1} max={8} step={1}/>
+            <br/> <br/> <br/>
+
+            <div className={styles["traitInfoTitle"]}>
+              MToon Atlas Size
+          </div>
+          <br />
+          <div className={styles["traitInfoText"]}>
+              Opaque: {getAtlasSize(atlasMtoon) + " x " + getAtlasSize(atlasMtoon)}
+          </div>
+
+            <Slider value = {atlasMtoon} onChange={(value) => handleChangeAtlasSize(value, 'mtoon opaque')} min={1} max={8} step={1}/>
+            <br/>
+            <div className={styles["traitInfoText"]}>
+              Transparent: {getAtlasSize(atlasMtoonTransp) + " x " + getAtlasSize(atlasMtoonTransp)}
+          </div>
+            <Slider value = {atlasMtoonTransp} onChange={(value) => handleChangeAtlasSize(value, 'mtoon transparent')} min={1} max={8} step={1}/>
+            <br/> <br/> <br/>
+
           <div className={styles["traitInfoTitle"]}>
               Drag Drop - Download
           </div>

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -296,13 +296,14 @@ function Optimizer({
           className={styles.buttonCenter}
           onClick={debugMode}
         /> */}
+        {(currentVRM)&&(
           <CustomButton
           theme="light"
           text="Download"
           size={14}
           className={styles.buttonRight}
           onClick={download}
-        />
+        />)}
       </div>
     </div>
   )

--- a/src/pages/Optimizer.jsx
+++ b/src/pages/Optimizer.jsx
@@ -47,6 +47,12 @@ function Optimizer({
       atlasSize : 4096,
       isVrm0 : true,
       createTextureAtlas : true,
+      mToonAtlasSize:getAtlasSize(atlasMtoon),
+      mToonAtlasSizeTransp:getAtlasSize(atlasMtoonTransp),
+      stdAtlasSize:getAtlasSize(atlasStd),
+      stdAtlasSizeTransp:getAtlasSize(atlasStdTransp),
+      exportStdAtlas:(currentOption === 0 || currentOption == 2),
+      exportMtoonAtlas:(currentOption === 1 || currentOption == 2)
     }
     downloadVRM(model, vrmData,nameVRM + "_merged", options)
   }

--- a/src/pages/Optimizer.module.css
+++ b/src/pages/Optimizer.module.css
@@ -9,33 +9,69 @@
     background: rgba(5, 11, 14, 0.8);
     z-index: 1000;
     user-select: none;
-  }
-  .traitInfoTitle {
-    color: white;
-    text-transform: uppercase;
-    text-shadow: 1px 1px 2px black;
-    font-size: 16px;
-    word-spacing: 2px;
-    margin-bottom: 10px;
-  }
-  .traitInfoText {
-    color: rgb(179, 179, 179);
-    /* text-transform: uppercase; */
-    text-shadow: 1px 1px 2px black;
-    font-size: 16px;
-    word-spacing: 2px;
-    margin-bottom: 10px;
-  }
-  .scrollContainer {
-    height: 100%;
-    width: 80%;
-    overflow-y: scroll;
-    position: relative;
-    overflow-x: hidden !important;
-    margin: 30px;
-    height: -webkit-calc(100% - 40px);
-    height: calc(100% - 40px);
-  }
+}
+.traitInfoTitle {
+  color: white;
+  text-transform: uppercase;
+  text-shadow: 1px 1px 2px black;
+  font-size: 16px;
+  word-spacing: 2px;
+  margin-bottom: 10px;
+}
+.traitInfoText {
+  color: rgb(179, 179, 179);
+  /* text-transform: uppercase; */
+  text-shadow: 1px 1px 2px black;
+  font-size: 16px;
+  word-spacing: 2px;
+  margin-bottom: 10px;
+}
+
+.flexSelect{
+  display: flex;
+  justify-content: space-between;
+  width: 90%;
+  height:40px;
+  align-items: center;
+}
+.arrow-button {
+  cursor: pointer;
+  overflow: hidden;
+  opacity: 0.8;
+  width: 32px;
+  height: 32px;
+  margin: 2px;
+  text-align: center;
+  outline-color: #3b434f;
+  outline-width: 2px;
+  outline-style: solid;
+  align-items: center;
+  background-color: #1e2530;
+}
+.left-button{
+  background: url('/ui/backButton_small.png');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.right-button{
+  background: url('/ui/nextButton_small.png');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.scrollContainer {
+  height: 100%;
+  width: 80%;
+  overflow-y: scroll;
+  position: relative;
+  overflow-x: hidden !important;
+  margin: 30px;
+  height: -webkit-calc(100% - 40px);
+  height: calc(100% - 40px);
+}
 /* Hide the default checkbox */
 .custom-checkbox input[type="checkbox"] {
     display: none;

--- a/src/pages/Optimizer.module.css
+++ b/src/pages/Optimizer.module.css
@@ -24,7 +24,7 @@
     text-shadow: 1px 1px 2px black;
     font-size: 16px;
     word-spacing: 2px;
-    margin-bottom: 30px;
+    margin-bottom: 10px;
   }
   .scrollContainer {
     height: 100%;


### PR DESCRIPTION
This PR cinludes:

- Support to keep standard material and mtoon material or merge them together
- Support separate materials when they have transparency
- Standard material will now include smoothness and metalness map
- Removed download button when user has not uploaded any model in omptimizer
- Pick atlas size for different atlases
- Save user selected options to local storage

![image](https://github.com/M3-org/CharacterStudio/assets/1117257/4aa83f8b-163d-4587-b7ad-68edefda40a6)
