### PR TITLE
remove vrm0 morph target modification

### DIFF
--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -694,12 +694,6 @@ function mergeSourceMorphAttributes({ meshes, sourceMorphTargetDictionaries, sou
         for (let i =0; i < Object.entries(destMorphTargetDictionary).length ; i++){
             merged[propName][i] = BufferGeometryUtils.mergeBufferAttributes(unmerged[propName][i]);
             const buffArr = merged[propName][i].array;
-            if (isVrm0){
-                for (let j = 0; j < buffArr.length; j+=3){
-                    buffArr[j] *= -1;
-                    buffArr[j+2] *= -1;
-                }
-            }
             for (let j = 0; j < buffArr.length; j+=3){
                 buffArr[j] *= scale;
                 buffArr[j+1] *= scale;


### PR DESCRIPTION
fix for #89 vrm blendshapes were exported with correct scale, but seems vertices does not need to be rotated for morph targets, removing this previous modification fxies the issue. In the images below the same morph target was activated

Current:
![image](https://github.com/M3-org/CharacterStudio/assets/1117257/4dda1894-99d8-403f-a0e8-c6e1cacfd72c)
After PR
![image](https://github.com/M3-org/CharacterStudio/assets/1117257/992eb3f8-f3a1-4c89-bea9-772e7e7dc275)

