### PR TITLE
Add bone count mismatch check in VRM exporte v0

### DIFF
--- a/src/library/VRMExporterv0.js
+++ b/src/library/VRMExporterv0.js
@@ -767,6 +767,19 @@ export default class VRMExporterv0 {
             extensionsUsed.push("KHR_texture_basisu");
         }
 
+        /**
+         * Check for bone count mismatch else the VRM will be broken
+         */
+        for(const skin of outputSkins){
+            const mats = outputAccessors.filter(acc => acc.type == "MAT4");
+            for(let m of mats){
+                if(skin.joints.length != m.count){
+                    throw new Error(`The number of joints in the skin is not equal to the number of Accessors of type MAT4. Got ${skin.joints.length} when accessors show ${m.count} This is usually because of a bone count mismatch in your VRMs!`);
+                }
+            }
+
+        }
+
         const outputData = {
             accessors: outputAccessors,
             asset: exporterInfo,


### PR DESCRIPTION
Adds a check in VRMexporterv0 to check the bone count when exporting; to be honest this should probably be done when loading the VRMs;

