### PR TITLE
add blendshapes as traits

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.1",
-    "@pixiv/three-vrm": "^1.0.9",
+    "@pixiv/three-vrm": "^3.1.1",
     "@react-spring/three": "^9.2.4",
     "@use-gesture/react": "^10.0.0-beta.22",
     "@vitejs/plugin-basic-ssl": "^1.0.1",

--- a/src/library/CharacterManifestData.js
+++ b/src/library/CharacterManifestData.js
@@ -769,7 +769,6 @@ export class BlendShapeGroup {
     this.trait = trait;
     this.name = name;
 
-
     this.cameraTarget = cameraTarget;
     this.createCollection(collection);
   }

--- a/src/library/characterManager.js
+++ b/src/library/characterManager.js
@@ -299,6 +299,19 @@ export class CharacterManager {
         return this.manifestData.getGroupModelTraits();
       }
     }
+      /**
+     * Same as getGroupTraits() but for Blendshapes
+     * @param {string} traitGroupId - The ID of the trait group.
+     * @param {string} traitId - The ID of the trait.
+     * @returns {Array} Array of blendshape traits
+     */
+    getBlendShapeGroupTraits(traitGroupId, traitId){
+      if (this.manifestData){
+        return this.manifestData.getModelTrait(traitGroupId, traitId)?.getGroupBlendShapeTraits()
+      }else {
+        return []
+      }
+    }
     getCurrentCharacterModel(){
       return this.characterModel;
     }
@@ -336,6 +349,13 @@ export class CharacterManager {
     }
     getCurrentTraitData(groupTraitID){
       return this.avatar[groupTraitID]?.traitInfo;
+    }
+    /**
+     * @param {string} groupTraitID 
+     * @returns {Object} Returns the current blendshape trait info for the specified group trait ID.
+     */
+    getCurrentBlendShapeTraitData(groupTraitID){
+      return this.avatar[groupTraitID]?.blendShapeTraitsInfo||{};
     }
     getCurrentTraitVRM(groupTraitID){
       return this.avatar[groupTraitID]?.vrm;
@@ -509,6 +529,30 @@ export class CharacterManager {
           reject(new Error(errorMessage));
         }
       });
+    }
+    /**
+     * Load and activate blendshape trait
+     * @param {string} traitGroupID 
+     * @param {string} blendshapeGroupId 
+     * @param {string} blendshapeTraitId 
+     * @returns 
+     */
+    loadBlendShapeTrait(traitGroupID, blendshapeGroupId,blendshapeTraitId){
+      const currentTrait = this.avatar[traitGroupID];
+      if(!currentTrait){
+        console.warn(`Trait with name: ${traitGroupID} was not found or not selected.`)
+        return;
+      }
+      if(!this.manifestData){
+        console.warn("No manifest data was found.")
+        return;
+      }
+
+      try{
+        this._loadBlendShapeTrait(traitGroupID, blendshapeGroupId, blendshapeTraitId);
+      }catch{ 
+        console.error("Error loading blendshape trait "+traitGroupID, blendshapeGroupId, blendshapeTraitId);
+      }
     }
 
     /**
@@ -879,6 +923,60 @@ export class CharacterManager {
         cullHiddenMeshes(this.avatar);
       })
     }
+
+    /**
+     * 
+     * @param {string} traitGroupID 
+     * @param {string} blendshapeGroupId 
+     * @param {string} blendshapeTraitId 
+     * @returns 
+     */
+    async _loadBlendShapeTrait(traitGroupID, blendshapeGroupId,blendshapeTraitId){
+      const currentTrait = this.avatar[traitGroupID];
+      if(!currentTrait){
+        console.warn(`Trait with name: ${traitGroupID} was not found or not selected.`)
+        return;
+      }
+      if(!currentTrait.blendShapeTraitsInfo){
+        currentTrait.blendShapeTraitsInfo = {};
+      }
+      if(currentTrait.blendShapeTraitsInfo[blendshapeGroupId]){
+        // Deactivate the current blendshape trait
+        this.toggleBinaryBlendShape(currentTrait.model, currentTrait.blendShapeTraitsInfo[blendshapeGroupId], false);
+      }
+
+      const blendShape = currentTrait.traitInfo.getBlendShape(blendshapeGroupId, blendshapeTraitId);
+      if(!blendShape){
+        console.warn(`Blendshape with name: ${blendshapeTraitId} was not found.`)
+        return;
+      }
+
+      // Apply blendshape to the model
+      this.toggleBinaryBlendShape(currentTrait.model, blendShape, true);
+
+      this.avatar[traitGroupID].blendShapeTraitsInfo[blendShape.getGroupId()] = blendShape;
+
+    }
+    /**
+     * 
+     * @param {THREE.Object3D} model 
+     * @param {BlendShapeTrait} blendshape 
+     * @param {boolean} enable 
+     */
+    toggleBinaryBlendShape = (model,blendshape,enable)=>{
+      model.traverse((child)=>{
+        if(child.isMesh || child.isSkinnedMesh){
+          const mesh = child;
+          if(!mesh.morphTargetDictionary || !mesh.morphTargetInfluences) return
+          const blendShapeIndex = mesh.morphTargetDictionary[blendshape.id];
+          if (blendShapeIndex != undefined){
+            mesh.morphTargetInfluences[blendShapeIndex] = enable?1:0;
+          }
+        }
+      })
+
+    }
+
     async _animationManagerSetup(paths, baseLocation, scale){
       const animationPaths = getAsArray(paths);
       if (this.animationManager){
@@ -1232,6 +1330,7 @@ export class CharacterManager {
       // to do, we are now able to load multiple vrm models per options, set the options to include vrm arrays
       this.avatar[traitGroupID] = {
         traitInfo: traitModel,
+        blendShapeTraitsInfo:{},
         textureInfo: textureTrait,
         colorInfo: colorTrait,
         name: traitModel.name,

--- a/src/library/characterManager.js
+++ b/src/library/characterManager.js
@@ -534,7 +534,7 @@ export class CharacterManager {
      * Load and activate blendshape trait
      * @param {string} traitGroupID 
      * @param {string} blendshapeGroupId 
-     * @param {string} blendshapeTraitId 
+     * @param {string|null} blendshapeTraitId 
      * @returns 
      */
     loadBlendShapeTrait(traitGroupID, blendshapeGroupId,blendshapeTraitId){
@@ -928,7 +928,7 @@ export class CharacterManager {
      * 
      * @param {string} traitGroupID 
      * @param {string} blendshapeGroupId 
-     * @param {string} blendshapeTraitId 
+     * @param {string|null} blendshapeTraitId 
      * @returns 
      */
     async _loadBlendShapeTrait(traitGroupID, blendshapeGroupId,blendshapeTraitId){
@@ -943,6 +943,11 @@ export class CharacterManager {
       if(currentTrait.blendShapeTraitsInfo[blendshapeGroupId]){
         // Deactivate the current blendshape trait
         this.toggleBinaryBlendShape(currentTrait.model, currentTrait.blendShapeTraitsInfo[blendshapeGroupId], false);
+      }
+      if(blendshapeTraitId == null){
+        // Deactivated the blendshape trait; dont do anything else
+        delete this.avatar[traitGroupID].blendShapeTraitsInfo[blendshapeGroupId]
+        return
       }
 
       const blendShape = currentTrait.traitInfo.getBlendShape(blendshapeGroupId, blendshapeTraitId);

--- a/src/library/download-utils.js
+++ b/src/library/download-utils.js
@@ -4,7 +4,7 @@ import { cloneSkeleton, combine, combineNoAtlas } from "./merge-geometry"
 import VRMExporter from "./VRMExporter"
 import VRMExporterv0 from "./VRMExporterv0"
 import { findChildrenByType } from "./utils"
-import { VRMHumanBoneName, VRMExpression, VRMExpressionPresetName, VRMExpressionManager,VRMExpressionMorphTargetBind} from "@pixiv/three-vrm";
+import { VRMHumanBoneName, VRMExpression, VRMExpressionPresetName, VRMExpressionManager, VRMExpressionMorphTargetBind} from "@pixiv/three-vrm";
 import { doesMeshHaveMorphTargetBoundToManager } from './utils';
 import { GetMetadataFromAvatar } from "./vrmMetaUtils"
 
@@ -416,7 +416,7 @@ function getRebindedVRMExpressionManager(avatarModel){
 
     /**
      * Get Weight from previous bind
-     * @param {import('@pixiv/three-vrm').VRMExpressionMorphTargetBind[]} binds
+     * @param {Object[]} binds
      * @param {number} indexToLookFor
      */
     const getPrevBoundWeight = (binds,indexToLookFor) => {

--- a/src/library/load-utils.js
+++ b/src/library/load-utils.js
@@ -1,5 +1,5 @@
 import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
+import {  GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
 import { getAsArray, renameVRMBones,getUniqueId } from "../library/utils"
 import { findChildByName } from '../library/utils';
 import { PropertyBinding,SkinnedMesh } from 'three';

--- a/src/library/load-utils.js
+++ b/src/library/load-utils.js
@@ -1,8 +1,8 @@
 import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
+import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
 import { getAsArray, renameVRMBones,getUniqueId } from "../library/utils"
 import { findChildByName } from '../library/utils';
-import { PropertyBinding } from 'three';
+import { PropertyBinding,SkinnedMesh } from 'three';
 
 export const loadVRM = async(url) => {
     const gltfLoader = new GLTFLoader()
@@ -27,7 +27,48 @@ export const loadVRM = async(url) => {
     }
     return vrm;
 }
+/**
+ * @param {GLTF} gltf 
+ */
+export const renameMorphTargets = (gltf) => {
+  const json = gltf.parser.json
+  const meshesJson = json.meshes;
+  const associations = gltf.parser.associations
+  
+  gltf.scene.traverse((child) => {
+    if(child instanceof SkinnedMesh){
+      if(child.morphTargetDictionary){
+        let hasEditedMorphs = false
+        const associationValues = associations.get(child)
+        if(typeof associationValues == 'undefined') return;
 
+        const meshIndex = associationValues.meshes||0;
+        const primitivesIndex = associationValues.primitives||0;
+        const meshJson = meshesJson[meshIndex]
+
+        const primitives = meshJson?.primitives[primitivesIndex]
+
+        if(primitives?.extras?.targetNames){
+          const targetNames = primitives.extras.targetNames;
+          for (let i = 0; i < targetNames.length; i++){
+            // console.log('assigning morphTargetDictionary',targetNames[i])
+            child.morphTargetDictionary[targetNames[i]] = i;
+            hasEditedMorphs = true;
+          }
+        }
+
+        if(hasEditedMorphs){
+          for(const key in child.morphTargetDictionary){
+            if(!isNaN(parseInt(key))){
+              delete child.morphTargetDictionary[key]
+            }
+          }
+        }
+      }
+    }
+  })
+
+}
 export const addVRMToScene = (vrm, scene) => {
   const vrmData = vrm.userData.vrm;
   renameVRMBones(vrmData);

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -799,7 +799,8 @@ function getVRMBoundExpressionMorphs(avatar){
             expressionNameDone.push(expression.expressionName)
             // Get the bound Blendshape from the expression
             /**
-             * @type {import('@pixiv/three-vrm').VRMExpressionMorphTargetBind[]}
+             *type VRMExpressionMorphTargetBind from pixiv VRM but cjs wont export it?
+             * @type {Object[]}
              */
             const bounds = expression._binds
             if(!bounds || bounds.length == 0) continue;

--- a/src/library/sceneInitializer.js
+++ b/src/library/sceneInitializer.js
@@ -47,7 +47,7 @@ export function sceneInitializer(canvasId) {
     controls.dampingFactor = 0.1;
 
     const minPan = new THREE.Vector3(-0.5, 0, -0.5);
-    const maxPan = new THREE.Vector3(0.5, 1.5, 0.5);
+    const maxPan = new THREE.Vector3(0.5, 1.7, 0.5);
 
     const handleResize = () => {
         renderer.setSize(window.innerWidth, window.innerHeight);

--- a/src/library/utils.js
+++ b/src/library/utils.js
@@ -180,8 +180,16 @@ export function getMaterialsSortedByArray (meshes){
 
   return { stdMats, stdCutoutpMats, stdTranspMats , mToonMats, mToonCutoutMats , mToonTranspMats }
 }
-
-export async function getModelFromScene(avatarScene, format = 'glb', skinColor = new THREE.Color(1, 1, 1), scale = 1) {
+/**
+ * @dev UNUSED ? To delete?
+ * @param {import("three/examples/jsm/Addons.js").GLTF} modelScene 
+ * @param {Object} avatar
+ * @param {string} [format] 
+ * @param {THREE.Color} [skinColor] 
+ * @param {number} [scale] 
+ * @returns 
+ */
+export async function getModelFromScene(modelScene,avatar, format = 'glb', skinColor = new THREE.Color(1, 1, 1), scale = 1) {
   if (format && format === 'glb') {
     const exporter = new GLTFExporter();
     const options = {
@@ -193,13 +201,13 @@ export async function getModelFromScene(avatarScene, format = 'glb', skinColor =
       maxTextureSize: 1024 || Infinity
     };
 
-    const avatar = await combine({ transparentColor: skinColor, avatar: avatarScene, scale:scale });
+    const avatarCombined = await combine(modelScene,avatar,{ transparentColor: skinColor, scale:scale });
 
-    const glb = await new Promise((resolve) => exporter.parse(avatar, resolve, (error) => console.error("Error getting model", error), options));
+    const glb = await new Promise((resolve) => exporter.parse(avatarCombined, resolve, (error) => console.error("Error getting model", error), options));
     return new Blob([glb], { type: 'model/gltf-binary' });
   } else if (format && format === 'vrm') {
     const exporter = new VRMExporter();
-    const vrm = await new Promise((resolve) => exporter.parse(avatarScene, resolve));
+    const vrm = await new Promise((resolve) => exporter.parse(modelScene, resolve));
     return new Blob([vrm], { type: 'model/gltf-binary' });
   } else {
     return console.error("Invalid format");
@@ -843,4 +851,25 @@ const describe = (function () {
 })();
 export function describeObject3D(root) {
     return traverseWithDepth({ object3D: root, callback: describe, result: [] }).join("\n");
+}
+
+
+/**
+ * 
+ * @param {THREE.Mesh} mesh 
+ * @param {{[key:string]:{
+ * index:number,
+ * primitives:number[]
+ *}}} oldDictionary 
+ * @returns 
+ */
+export function doesMeshHaveMorphTargetBoundToManager(mesh, oldDictionary){
+  if(!mesh.morphTargetDictionary) return false
+
+  for(const key of Object.keys(mesh.morphTargetDictionary)){
+    if(oldDictionary[key]){
+      return true
+    }
+  }
+  return false
 }

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -11,7 +11,7 @@ import FileDropComponent from "../components/FileDropComponent"
 import { getFileNameWithoutExtension } from "../library/utils"
 import MenuTitle from "../components/MenuTitle"
 import BottomDisplayMenu from "../components/BottomDisplayMenu"
-
+import {BlendShapeTrait} from '../library/CharacterManifestData'
 import { TokenBox } from "../components/token-box/TokenBox"
 import JsonAttributes from "../components/JsonAttributes"
 import cancel from "../images/cancel.png"
@@ -464,9 +464,14 @@ const BlendShapeTraitView = ({selectedTrait,onBack,selectedBlendShapeTrait,setSe
    * @param {import('../library/CharacterManifestData').BlendShapeTrait} newBlendShape 
    */
   const selectBlendShapeTrait = (newBlendShape)=>{
+    if(newBlendShape.id==null){
+      const parent = newBlendShape.parentGroup;
+      characterManager.loadBlendShapeTrait(selectedTrait?.traitGroup.trait||"",parent.trait||"",null);
+      return 
+    }
     const parent = newBlendShape.parentGroup;
     characterManager.loadBlendShapeTrait(selectedTrait?.traitGroup.trait||"",parent.trait||"",newBlendShape?.id||'');
-    moveCamera({ targetY: newBlendShape.cameraTarget.height, distance: newBlendShape.cameraTarget.distance})
+    moveCamera({ targetY: parent.cameraTarget.height, distance: parent.cameraTarget.distance})
     const prev = {...selectedBlendShapeTrait};
     prev[parent.trait||''] = newBlendShape.id;
     setSelectedBlendshapeTrait(prev);
@@ -486,6 +491,12 @@ const BlendShapeTraitView = ({selectedTrait,onBack,selectedBlendShapeTrait,setSe
             <div key={group.trait} className={styles.blendshapeGroup}> 
               <div>{group.name}</div>
               <div className={styles["selector-container"]} >
+                <BlendShapeItem key={"empty"}
+                    src={cancel}
+                    active={!selectedBlendShapeTrait[group.trait]}
+                    blendshapeID="cancel"
+                    select={()=>selectBlendShapeTrait(new BlendShapeTrait(group,{id:null}))}
+                    />
                 {group.collection.map((blendShapeTrait)=>{
                   let active = blendShapeTrait.id === selectedBlendShapeTrait[group.trait]
                   return (

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -128,7 +128,7 @@ function Appearance() {
   }
   const selectTrait = (trait) => {
     if(trait.id === selectedTrait?.id){
-      if(trait.blendshapeTraits){
+      if(trait.blendshapeTraits?.length>0){
         setTraitView(TraitPage.BLEND_SHAPE);
       }
       // We already selected this trait, do nothing
@@ -139,7 +139,7 @@ function Appearance() {
     setIsLoading(true);
     characterManager.loadTrait(trait.traitGroup.trait, trait.id).then(()=>{
       setIsLoading(false);
-      if(trait.blendshapeTraits){
+      if(trait.blendshapeTraits?.length>0){
         const selectedBlendshapeTrait = characterManager.getCurrentBlendShapeTraitData(trait.traitGroup.trait);
         setSelectedBlendshapeTraits(Object.entries(selectedBlendshapeTrait).reduce((acc,[key,value])=>{acc[key]=value.id;return acc},{}))
         setTraitView(TraitPage.BLEND_SHAPE);
@@ -230,6 +230,7 @@ function Appearance() {
     !isMute && playSound('optionClick');
     setIsPickingColor(false);
     if (traitGroupName !== traitGroup.trait){
+      setTraitView(TraitPage.TRAIT);
       setTraits(characterManager.getTraits(traitGroup.trait));
       setTraitGroupName(traitGroup.trait);
 

--- a/src/pages/Appearance.jsx
+++ b/src/pages/Appearance.jsx
@@ -455,7 +455,7 @@ export default Appearance
  * @param {{selectedTrait:ModelTrait|null,selectedBlendShapeTrait:Record<string,string>,onBack:()=>void,setSelectedBlendshapeTrait:(x:Record<string,string>)=>void}} param0 
  */
 const BlendShapeTraitView = ({selectedTrait,onBack,selectedBlendShapeTrait,setSelectedBlendshapeTrait})=>{
-  const {characterManager} = React.useContext(SceneContext);
+  const {characterManager,moveCamera} = React.useContext(SceneContext);
 
   const groups = characterManager.getBlendShapeGroupTraits(selectedTrait?.traitGroup.trait||"",selectedTrait?.id||"");
 
@@ -466,7 +466,7 @@ const BlendShapeTraitView = ({selectedTrait,onBack,selectedBlendShapeTrait,setSe
   const selectBlendShapeTrait = (newBlendShape)=>{
     const parent = newBlendShape.parentGroup;
     characterManager.loadBlendShapeTrait(selectedTrait?.traitGroup.trait||"",parent.trait||"",newBlendShape?.id||'');
-
+    moveCamera({ targetY: newBlendShape.cameraTarget.height, distance: newBlendShape.cameraTarget.distance})
     const prev = {...selectedBlendShapeTrait};
     prev[parent.trait||''] = newBlendShape.id;
     setSelectedBlendshapeTrait(prev);

--- a/src/pages/Appearance.module.css
+++ b/src/pages/Appearance.module.css
@@ -126,6 +126,14 @@
   width: 140px;
   position: relative;
 }
+.selector-container-column {
+  user-select: none;
+  flex: 1;
+  flex-direction: column;
+  width: 140px;
+  position: relative;
+}
+
 .selectorButton {
   padding: 0.25em;
   display: block;
@@ -191,4 +199,14 @@
   align-items : center;
   user-select: none;
   cursor: pointer;
+}
+
+.relativeBox{
+  position: relative;
+}
+
+.blendshapeGroup{
+  flex-direction: column;
+  display: flex;
+  color: white;
 }


### PR DESCRIPTION
On select of a blendshapeTrait, we activate the blendshape;

When we export them, the logic goes as follows:
- If any VRMExpression Blendshapes are present (blendshapes bound to VRMExpressionManager) we keep them and export them with the VRM;
- If any Blendshapes not defined in the manifest are present, they will be exported with the VRM as usual;
- If any Blendshapes defined in the manifest has influence = 0 we remove it;
- if any Blendshapes defined in the manifest has influence >0 we merge the influence into the geometry and we remove the blendshape from the blendshapes

I haven't tested how it behaves on a VRM 1

To add blendshape as traits, one needs to add details into the manifest
root or manifest.json -> traits ->collection - >blendshapeTraits

Note that this will treat the blendshapes as binary (regardless if they are actually binary or not)

Example:
```
... ,
        "blendshapeTraits":[{
            "trait":"mouth",
            "name":"Mouth",
            "cameraTarget": {
              "distance": 0.75,
              "height": 1.35
            },
            "collection":[{
              "id":"Male_Mouth_002",
              "name":"Large Lips"
            }]
          },{
            "trait":"nose",
            "name":"Nose",
            "cameraTarget": {
              "distance": 0.75,
              "height": 1.35
            },
            "collection":[{
              "id":"Male_Nose_007",
              "name":"Thick"
            },{
              "id":"Male_Nose_006",
              "name":"Rectangular"
            },{
              "id":"Male_Nose_005",
              "name":"Robert"
            },{
              "id":"Male_Nose_004",
              "name":"Thin"
            }]
          }
          ]
        }
```