### PR TITLE
Fix mesh with same material

### DIFF
--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -1,10 +1,9 @@
 import * as THREE from "three";
-import { mergeGeometry } from "./merge-geometry.js";
+import { mergeGeometry,convertMergedDataToGeometry } from "./merge-geometry.js";
 import { MToonMaterial } from "@pixiv/three-vrm";
 import squaresplit from 'squaresplit';
 import {createContext} from "./utils.js";
 import TextureImageDataRenderer from "./textureImageDataRenderer.js";
-
 
 function getTextureImage(material, textureName) {
 
@@ -167,8 +166,9 @@ export const createTextureAtlasNode = async ({ meshes, atlasSize, mtoon, transpa
  * @param {boolean} params.transparentMaterial - Whether the material is transparent.
  * @param {boolean} params.transparentTexture - Whether the texture is transparent.
  * @param {boolean} params.twoSidedMaterial - Whether the material is two-sided.
+ * @param {number} params.scale - The scale factor for the meshes.
  */
-export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedMeshesInAtlas=false,meshes, atlasSize, mtoon, transparentMaterial, transparentTexture, twoSidedMaterial }) => {
+export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedMeshesInAtlas=false,meshes, atlasSize, mtoon, transparentMaterial, transparentTexture, twoSidedMaterial, scale=1}) => {
   const ATLAS_SIZE_PX = atlasSize;
   const IMAGE_NAMES = mtoon ? ["diffuse"] : ["diffuse", "orm", "normal"];// not using normal texture for now
   const bakeObjects = [];
@@ -187,17 +187,30 @@ export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedM
       vrmMaterial = material.clone();
     }
     // check if bakeObjects objects that contain the material property with value of mesh.material
-    let bakeObject = bakeObjects.find((bakeObject) => {
-      bakeObject.material === material;
-    });
+    let bakeObject = bakeObjects.find((bakeObject) => bakeObject.material === material);
     if (!bakeObject) {
-      bakeObjects.push({ material, mesh });
+      bakeObjects.push({ material, mesh, sibligs:[] });
     }
     else {
-      const { dest } = mergeGeometry({ meshes: [bakeObject.mesh, mesh] });
-      bakeObject.mesh.geometry = dest;
+      
+      if(bakeObject.mesh.morphTargetDictionary && Object.keys(bakeObject.mesh.morphTargetDictionary).length > 0){
+        /**
+         * For meshes with morph targets, merging the geometry will not work, it's broken at the moment.
+         * use sibling system where the meshes stay separate but share the same material
+         */
+          bakeObject.siblings.push(mesh);
+      }else{
+        // @TODO fix this
+        const { dest,destMorphToMerge} = mergeGeometry({
+          meshes: [bakeObject.mesh, mesh],
+          scale,
+        });
+        const geometry = convertMergedDataToGeometry(dest, destMorphToMerge,true,scale,true);
+        bakeObject.mesh.geometry = geometry;
+
+      }
     }
-  });
+  })
 
   // create the canvas to draw textures
   //transparent: (name == "diffuse" && drawTransparent)
@@ -283,11 +296,24 @@ export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedM
             continue;
           }
         }
+        
         bakeObjectsWithSameMaterial.set(material,[bakeObject.mesh])
         return [bakeObject.mesh, 1];// assign small space
       }
     }
-    
+      /**
+       * We have siblings, add them to the bakeObjectsWithSameMaterial map
+       */
+      if (
+        bakeObject.siblings.length > 0
+      ){
+        if(bakeObjectsWithSameMaterial.has(bakeObject.material)){
+          bakeObjectsWithSameMaterial.get(bakeObject.material)?.push(...bakeObject.siblings,bakeObject.mesh);
+        }else{
+          bakeObjectsWithSameMaterial.set(bakeObject.material, [bakeObject.mesh,...bakeObject.siblings]);
+        }
+      }
+
     return [bakeObject.mesh, geometry.index ? geometry.index.count / 3 : geometry.attributes.position.count / 3];
   }).sort((a, b) => b[1] - a[1]);
   
@@ -378,7 +404,9 @@ export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedM
   let usesNormal = false;
   const textureImageDataRenderer = new TextureImageDataRenderer(ATLAS_SIZE_PX, ATLAS_SIZE_PX);
   Array.from(tileSize.keys()).forEach((mesh) => {
-    const bakeObject = bakeObjects.find((bakeObject) => bakeObject.mesh === mesh);
+    const bakeObject = bakeObjects.find(
+      (bakeObject) => bakeObject.mesh === mesh || bakeObject.siblings.includes(mesh)
+    );
     const { material } = bakeObject;
     let min, max;
     const uvMinMax = uvs.get(mesh);
@@ -540,6 +568,25 @@ export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedM
     if (material.normalMap != null)
       material.normalMap.name = material.name + "_normal";
   }
+
+
+  /**
+   * We're done creating the atlas, Remove siblings and bring them back into the bakeObject list
+   */
+  const siblings = []
+  
+  bakeObjects.map((bakeObject) => {
+    bakeObject.siblings.forEach((sibling) => {
+      const material = bakeObject.material;
+      siblings.push({
+        material,
+        mesh: sibling,
+        siblings: [],
+      })
+    })
+  });
+  bakeObjects.push(...siblings);
+
   // xxxreturn material with textures, dont return uvs nor textures
   return { bakeObjects, material };
 };

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { mergeGeometry,convertMergedDataToGeometry } from "./merge-geometry.js";
+import { mergeGeometry } from "./merge-geometry.js";
 import { MToonMaterial } from "@pixiv/three-vrm";
 import squaresplit from 'squaresplit';
 import {createContext} from "./utils.js";

--- a/src/library/create-texture-atlas.js
+++ b/src/library/create-texture-atlas.js
@@ -192,23 +192,10 @@ export const createTextureAtlasBrowser = async ({ backColor, includeNonTexturedM
       bakeObjects.push({ material, mesh, sibligs:[] });
     }
     else {
-      
-      if(bakeObject.mesh.morphTargetDictionary && Object.keys(bakeObject.mesh.morphTargetDictionary).length > 0){
-        /**
-         * For meshes with morph targets, merging the geometry will not work, it's broken at the moment.
-         * use sibling system where the meshes stay separate but share the same material
-         */
-          bakeObject.siblings.push(mesh);
-      }else{
-        // @TODO fix this
-        const { dest,destMorphToMerge} = mergeGeometry({
-          meshes: [bakeObject.mesh, mesh],
-          scale,
-        });
-        const geometry = convertMergedDataToGeometry(dest, destMorphToMerge,true,scale,true);
-        bakeObject.mesh.geometry = geometry;
+        // @IMPROVEMENT: Merge meshes with the same material instead of keeping them separate; BUT make sure you merge morph targets and handle VRM expression bind changes!!!
 
-      }
+        // In the meantime, we use the siblings system to keep track of the meshes that share the same material; This allows us to have shared materials for some meshes.
+          bakeObject.siblings.push(mesh);
     }
   })
 

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -1268,3 +1268,59 @@ export function mergeGeometry({ meshes, scale, morphTargetsProcess }, isVrm0 = f
 
     return { source, dest, destMorphToMerge};
 }
+
+/**
+ * 
+ * @param {ReturnType<typeof mergeGeometry>['dest']} dest 
+ * @param {ReturnType<typeof mergeGeometry>['destMorphToMerge']} destMorphToMerge 
+ * @param {boolean} mergeAppliedMorphs 
+ * @param {number} scale 
+ * @param {boolean} isVrm0 
+ * @returns 
+ */
+
+export function convertMergedDataToGeometry(dest,destMorphToMerge,mergeAppliedMorphs, scale, isVrm0 = false){
+
+    const geometry = new THREE.BufferGeometry();
+
+    // modify all merged vertices to reflect vrm0 format
+    if (isVrm0){
+        for (let i = 0; i < dest.attributes.position.array.length; i+=3){
+            //@ts-ignore
+            dest.attributes.position.array[i] *= -1
+            //@ts-ignore
+            dest.attributes.position.array[i+2] *= -1
+        }
+    }
+
+    geometry.attributes = dest.attributes;
+    geometry.morphAttributes = dest.morphAttributes;
+    geometry.morphTargetsRelative = true;
+    geometry.setIndex(dest.index);
+
+    const vertices = geometry.attributes.position.array;
+    for (let i = 0; i < vertices.length; i += 3) {
+        //@ts-ignore
+        vertices[i] *= scale;
+        //@ts-ignore
+        vertices[i + 1] *= scale;
+        //@ts-ignore
+        vertices[i + 2] *= scale;
+
+        // Apply morph targets to the vertices
+        if(mergeAppliedMorphs){
+            if(!destMorphToMerge.morphTargetInfluences)continue
+            for (let j = 0; j < destMorphToMerge.morphTargetInfluences.length; j++) {
+                const morphAttribute = destMorphToMerge.morphAttributes?.position[j];
+                if (morphAttribute) {
+                    for (let k = 0; k < 3; k++) {
+                        //@ts-ignore
+                        vertices[i + k] += morphAttribute.array[i + k] * destMorphToMerge.morphTargetInfluences[j];
+                    }
+                }
+            }
+        }
+    }
+
+    return geometry;
+}

--- a/src/library/merge-geometry.js
+++ b/src/library/merge-geometry.js
@@ -692,40 +692,7 @@ export async function combine(model,avatar, options) {
             });
             const { dest, destMorphToMerge } = mergeGeometry({ meshes:skinnedMeshes, scale , morphTargetsProcess },isVrm0);
             console.log('destMorphToMerge',destMorphToMerge)
-            const geometry = new THREE.BufferGeometry();
-
-
-            for (let i = 0; i < dest.attributes.position.array.length; i+=3){
-                dest.attributes.position.array[i] *= -1
-                dest.attributes.position.array[i+2] *= -1
-            }
-            
-
-            geometry.attributes = dest.attributes;
-            geometry.morphAttributes = dest.morphAttributes;
-            geometry.morphTargetsRelative = true;
-            geometry.setIndex(dest.index);
-
-            const vertices = geometry.attributes.position.array;
-            for (let i = 0; i < vertices.length; i += 3) {
-                vertices[i] *= scale;
-                vertices[i + 1] *= scale;
-                vertices[i + 2] *= scale;
-
-                // Apply morph targets to the vertices
-                if(mergeAppliedMorphs){
-                    if(!destMorphToMerge.morphTargetInfluences)continue
-                    for (let j = 0; j < destMorphToMerge.morphTargetInfluences.length; j++) {
-                        const morphAttribute = destMorphToMerge.morphAttributes?.position[j];
-                        if (morphAttribute) {
-                            for (let k = 0; k < 3; k++) {
-                                vertices[i + k] += morphAttribute.array[i + k] * destMorphToMerge.morphTargetInfluences[j];
-                            }
-                        }
-                    }
-                }
-            }
-
+            const geometry = convertMergedDataToGeometry(dest,destMorphToMerge,mergeAppliedMorphs,scale, isVrm0);
 
             const mesh = new THREE.SkinnedMesh(geometry, material);
             mesh.name = "CombinedMesh_" + prop;


### PR DESCRIPTION
There was a bug in create-texture-atlas.js where the find would always return undefined because we never returned the function;
```js
    let bakeObject = bakeObjects.find((bakeObject) => {bakeObject.material === material});
 ```
 
 Fixing this opened a huge can of worms because of the `mergeGeometry`. Merging the geometry means having to handle the morphTarget merging and therefore having to merge the VRMExpression binds appropriately.
 
 This was too complex for the task.
 
 I decided to fix this by using a "siblings" system.
 
 If a mesh has the same material as another we add it as a sibling to the latter. We then handle the siblings accordingly in the create-atlas section.
 Once the atlas and the new material is created, we bring the siblings back into `bakedObjects`